### PR TITLE
Some upgrades to stat system

### DIFF
--- a/classes/classes/Creature.as
+++ b/classes/classes/Creature.as
@@ -25,6 +25,7 @@ import classes.GlobalFlags.kFLAGS;
 import classes.Items.JewelryLib;
 import classes.Scenes.Places.TelAdre.UmasShop;
 import classes.Stats.Buff;
+import classes.Stats.BuffBuilder;
 import classes.Stats.BuffableStat;
 import classes.Stats.PrimaryStat;
 import classes.Stats.RawStat;
@@ -274,6 +275,10 @@ public class Creature extends Utils
 			'sens': new BuffableStat({base: 15, min: 0})
 		});
 		public function get statStore():StatStore { return _stats; }
+		
+		public function buff(tag:String):BuffBuilder {
+			return new BuffBuilder(statStore, tag);
+		}
 
 		//new stat area
 		public var strStat:PrimaryStat = _stats.findStat('str') as PrimaryStat;

--- a/classes/classes/Stats/BuffBuilder.as
+++ b/classes/classes/Stats/BuffBuilder.as
@@ -1,0 +1,131 @@
+package classes.Stats {
+import classes.Stats.BuffableStat;
+import classes.internals.Utils;
+
+public class BuffBuilder {
+	
+	private var store: StatStore;
+	private var tag: String;
+	private var options: Object = {};
+	
+	public function BuffBuilder(store: StatStore, tag: String) {
+		this.store = store;
+		this.tag = tag;
+	}
+	
+	// Utility functions
+	
+	public function present(): Boolean {
+		return store.hasBuff(tag);
+	}
+	public function buffObjects(): /*Buff*/Array {
+		return store.buffObjects(tag);
+	}
+	public function buffObjectOfStat(statName:String): Buff {
+		var stat:BuffableStat = store.findBuffableStat(statName);
+		return stat.findBuff(tag);
+	}
+	public function ticksLeft():int {
+		var buff:Buff = store.buffObjects(tag)[0];
+		if (buff) return buff.tick;
+		return 0;
+	}
+	public function buffOfStat(statName:String): Number {
+		var stat:BuffableStat = store.findBuffableStat(statName);
+		return stat.valueOfBuff(tag);
+	}
+	
+	// Builder functions
+	
+	public function remove(): BuffBuilder {
+		store.removeBuffs(tag);
+		return this;
+	}
+	public function addStat(statName: String, value: Number): BuffBuilder {
+		store.findBuffableStat(statName).addOrIncreaseBuff(tag, value, options);
+		return this;
+	}
+	public function setStat(statName: String, value: Number): BuffBuilder {
+		store.findBuffableStat(statName).addOrReplaceBuff(tag, value, options);
+		return this;
+	}
+	public function addStats(buffObject: Object): BuffBuilder {
+		store.addBuffObject(buffObject, tag, options);
+		return this;
+	}
+	public function setStats(buffObject: Object): BuffBuilder {
+		store.replaceBuffObject(buffObject, tag, options);
+		return this;
+	}
+	public function withOptions(options:*): BuffBuilder {
+		Utils.extend(this.options, options);
+		store.setBuffOptions(tag, options);
+		return this;
+	}
+	public function withText(text: String): BuffBuilder {
+		return withOptions({text:text});
+	}
+	public function permanent(): BuffBuilder {
+		return withOptions({rate:Buff.RATE_PERMANENT, tick:0});
+	}
+	public function forHours(hours:int): BuffBuilder {
+		return withOptions({rate:Buff.RATE_HOURS, tick:hours});
+	}
+	public function forDays(days:int): BuffBuilder {
+		return withOptions({rate:Buff.RATE_HOURS, tick:days});
+	}
+	public function combatTemporary(rounds:int): BuffBuilder {
+		return withOptions({rate:Buff.RATE_ROUNDS, tick:rounds});
+	}
+	public function combatPermanent(): BuffBuilder {
+		return withOptions({rate:Buff.RATE_ROUNDS, tick:Infinity});
+	}
+	public function addDuration(ticks:int): BuffBuilder {
+		store.addTicksToBuffs(tag, ticks);
+		return this;
+	}
+	
+	// Utility functions for particular stats go here
+	
+	public function addStr(value: Number): BuffBuilder {
+		return addStat("str", value);
+	}
+	public function addStrMult(value: Number): BuffBuilder {
+		return addStat("str.mult", value);
+	}
+	public function addTou(value: Number): BuffBuilder {
+		return addStat("tou", value);
+	}
+	public function addTouMult(value: Number): BuffBuilder {
+		return addStat("tou.mult", value);
+	}
+	public function addSpe(value: Number): BuffBuilder {
+		return addStat("spe", value);
+	}
+	public function addSpeMult(value: Number): BuffBuilder {
+		return addStat("spe.mult", value);
+	}
+	public function addInt(value: Number): BuffBuilder {
+		return addStat("int", value);
+	}
+	public function addIntMult(value: Number): BuffBuilder {
+		return addStat("int.mult", value);
+	}
+	public function addWis(value: Number): BuffBuilder {
+		return addStat("wis", value);
+	}
+	public function addWisMult(value: Number): BuffBuilder {
+		return addStat("wis.mult", value);
+	}
+	public function addLib(value: Number): BuffBuilder {
+		return addStat("lib", value);
+	}
+	public function addLibMult(value: Number): BuffBuilder {
+		return addStat("lib.mult", value);
+	}
+	public function addSens(value: Number): BuffBuilder {
+		return addStat("sens", value);
+	}
+	
+}
+}

--- a/classes/classes/Stats/BuffBuilder.as
+++ b/classes/classes/Stats/BuffBuilder.as
@@ -15,22 +15,22 @@ public class BuffBuilder {
 	
 	// Utility functions
 	
-	public function present(): Boolean {
+	public function isPresent(): Boolean {
 		return store.hasBuff(tag);
 	}
-	public function buffObjects(): /*Buff*/Array {
+	public function findAllBuffObjects(): /*Buff*/Array {
 		return store.buffObjects(tag);
 	}
-	public function buffObjectOfStat(statName:String): Buff {
+	public function findBuffObjectOfStat(statName:String): Buff {
 		var stat:BuffableStat = store.findBuffableStat(statName);
 		return stat.findBuff(tag);
 	}
-	public function ticksLeft():int {
+	public function getRemainingTicks():int {
 		var buff:Buff = store.buffObjects(tag)[0];
 		if (buff) return buff.tick;
 		return 0;
 	}
-	public function buffOfStat(statName:String): Number {
+	public function getValueOfStatBuff(statName:String): Number {
 		var stat:BuffableStat = store.findBuffableStat(statName);
 		return stat.valueOfBuff(tag);
 	}

--- a/classes/classes/Stats/BuffableStat.as
+++ b/classes/classes/Stats/BuffableStat.as
@@ -229,7 +229,7 @@ public class BuffableStat implements IStat, Jsonable {
 			var buff:Buff = _buffs[i];
 			if (buff.rate == rate) {
 				buff.tick-=ticks;
-				if (buff.tick < 0) {
+				if (buff.tick <= 0) {
 					recentlyRemovedTags[buff.tag] = true;
 					_buffs.splice(i,1);
 					changed = true;

--- a/classes/classes/Stats/StatStore.as
+++ b/classes/classes/Stats/StatStore.as
@@ -9,6 +9,12 @@ import coc.script.Eval;
 public class StatStore implements IStatHolder {
 	private var _stats:Object = {};
 	/**
+	 * Set of buff tags (key is tag and value is true) that were removed since last
+	 * `advanceTime`, `removeCombatRoundTrackingBuffs`, or `addTicksToBuffs` call.
+	 */
+	public var recentlyRemovedTags:Object = {};
+	
+	/**
 	 * @param setup object { [statName:String] => IStat }
 	 */
 	public function StatStore(setup:Object =null) {
@@ -40,16 +46,27 @@ public class StatStore implements IStatHolder {
 	}
 	/**
 	 * Advance time-tracking buffs by `ticks` units, unit type is defined by `rate`
-	 * Buffs with their countdown expired are removed
+	 * Buffs with their countdown expired are removed.
+	 *
+	 * Will reset & populate `recentlyRemovedTags`
 	 */
 	public function advanceTime(rate:int, ticks:int):void {
+		recentlyRemovedTags = {};
 		forEachStat(function(stat:BuffableStat):void{
-			stat.advanceTime(rate, ticks)
+			stat.advanceTime(rate, ticks);
+			Utils.extend(recentlyRemovedTags, stat.recentlyRemovedTags);
 		},BuffableStat);
 	}
+	/**
+	 * Remove all buffs with `rate == RATE_ROUNDS`.
+	 *
+	 * Will reset & populate `recentlyRemovedTags`
+	 */
 	public function removeCombatRoundTrackingBuffs():void {
+		recentlyRemovedTags = {};
 		forEachStat(function(stat:BuffableStat):void{
-			stat.removeCombatRoundTrackingBuffs()
+			stat.removeCombatRoundTrackingBuffs();
+			Utils.extend(recentlyRemovedTags, stat.recentlyRemovedTags);
 		},BuffableStat);
 	}
 	
@@ -113,8 +130,10 @@ public class StatStore implements IStatHolder {
 	 * Does nothing if no such buffs or they are permanent
 	 */
 	public function addTicksToBuffs(tag: String, amount: Number):void {
+		recentlyRemovedTags = {};
 		forEachStat(function(stat:BuffableStat):void{
 			stat.addTicksToBuff(tag, amount);
+			Utils.extend(recentlyRemovedTags, stat.recentlyRemovedTags);
 		},BuffableStat);
 	}
 

--- a/classes/classes/Stats/StatStore.as
+++ b/classes/classes/Stats/StatStore.as
@@ -124,6 +124,14 @@ public class StatStore implements IStatHolder {
 		},BuffableStat);
 		return result;
 	}
+	public function buffObjects(tag:String):/*Buff*/Array {
+		var result:/*Buff*/Array = [];
+		forEachStat(function(stat:BuffableStat):void{
+			var buff:Buff = stat.findBuff(tag);
+			if (buff) result.push(buff);
+		},BuffableStat);
+		return result;
+	}
 
 	/**
 	 * Add `amount` ticks to all buffs tagged `tag`.
@@ -142,6 +150,13 @@ public class StatStore implements IStatHolder {
 	}
 	public function addBuffObject(buffs:Object, tag:String, options:*=null, evalContext:*=null):void {
 		applyBuffObject(buffs, tag, options, evalContext, false);
+	}
+	public function setBuffOptions(tag: String, options:*):void {
+		if(!options) return;
+		forEachStat(function(stat:BuffableStat):void{
+			var buff:Buff = stat.findBuff(tag);
+			if (buff) buff.options = options;
+		}, BuffableStat);
 	}
 	private function applyBuffObject(buffs:Object, tag:String, options:*, evalContext:*, replaceMode:Boolean=false):void {
 		for (var statname:String in buffs) {

--- a/classes/classes/internals/Utils.as
+++ b/classes/classes/internals/Utils.as
@@ -108,6 +108,13 @@ package classes.internals
 			return r;
 		}
 		/**
+		 * Append all values to target. Return target.
+		 */
+		public static function pushAll(target:Array, values:Array):Array {
+			target.push.apply(target, values);
+			return target;
+		}
+		/**
 		 * @return src.map( el => el['propname'] )
 		 */
 		public static function mapOneProp(src:Array,propname:String):Array {


### PR DESCRIPTION
1. Instead of `applyBuffObject` you can use safe builders. Just start with `player.buff('Tag goes here').` and follow IDE autocomplete. Example:
```as
player.buff('DebugCurse')
      .addStat('sens',+10)
      .withText('Debug buff!')
      .forHours(2);
```
2. When advancing time, a `recentlyRemovedTags` object in StatStore and BuffableStat is updated. Example:
```as
player.statStore.advanceTime(Buff.RATE_ROUNDS,1);
if (player.statStore.recentlyRemovedTags["Might"]) {
    // Buff tagged Might was removed just now
}
```
3. Fixed buffs lasting 1 more tick than needed.